### PR TITLE
Fix `setuptools` error in Docker dspython build

### DIFF
--- a/dspython/Dockerfile
+++ b/dspython/Dockerfile
@@ -9,7 +9,7 @@ ARG PYTHON_PIP_VERSION=3
 
 # Install extrae requirements
 RUN apt-get update \
-       && apt-get install --no-install-recommends -y --allow-unauthenticated python${DATACLAY_PYVER} python${DATACLAY_PYVER}-dev python${PYTHON_PIP_VERSION}-pip \
+       && apt-get install --no-install-recommends -y --allow-unauthenticated python${DATACLAY_PYVER} python${DATACLAY_PYVER}-dev python${PYTHON_PIP_VERSION}-pip python3-setuptools \
        && rm -rf /var/lib/apt/lists/*
 
 #beginENVruntime


### PR DESCRIPTION
This adds python3-setuptools as a package that should be installed for Python

@pierlauro was the first to realize the error, but was not ready to do the PR.