### PR TITLE
Same entrypoint for docker and singularity

### DIFF
--- a/build_singularity.sh
+++ b/build_singularity.sh
@@ -41,8 +41,10 @@ do
 	do
 		extract_env $DOCKERFILE_PATH/Dockerfile >> $RECIPE
 	done
+	# docker entripoint is in /.singularity.d/runscript
+	# singularity entripoint is in /.singularity.d/startscript
+	# following, we couple docker and singularity entrypoints
 	echo "%startscript" >> $RECIPE
-	ENTRYPOINT=`grep ^ENTRYPOINT $IMAGE/Dockerfile | cut -d' ' -f 2- | tr -d '"\|\[\|\]' | tr -s ',' ' '`
-	echo -e "\texec $ENTRYPOINT" >> $RECIPE
+	echo -e "\t"'exec /.singularity.d/runscript $@' >> $RECIPE
 	singularity build "$SINGULARITY_FOLDER/$IMAGE.sif" $RECIPE
 done


### PR DESCRIPTION
The new singularity version is automatically identifying a docker image's entrypoint and putting it in `/.singularity.d/runscript`, it is therefore not needed to parse the original Dockerfile.
In this PR, we are just letting singularity's entrypoint `/.singularity.d/startscript` point to the right original docker entrypoint.

By harmonizing runscript and startscript, `singularity run` or `singularity instance start` will call the same entrypoint (more details [HERE](https://sylabs.io/guides/3.5/user-guide/environment_and_metadata.html?highlight=runscript)).
FYI, singularity-compose up is calling `singularity instance start`.